### PR TITLE
Test unitarios para las funcionalidades de libro digital

### DIFF
--- a/src/test/java/com/iesam/digitallibrary/features/ebook/domain/DeleteEBookUseCaseTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/ebook/domain/DeleteEBookUseCaseTest.java
@@ -1,0 +1,68 @@
+package com.iesam.digitallibrary.features.ebook.domain;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteEBookUseCaseTest {
+    @Mock
+    EBookRepository eBookRepository;
+
+    DeleteEBookUseCase deleteEBookUseCase;
+
+    @BeforeEach
+    void setUp() {
+        deleteEBookUseCase = new DeleteEBookUseCase(eBookRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        deleteEBookUseCase = null;
+    }
+
+    @Test
+    public void deletingAnExistingEBookByIsbn(){
+        //Given
+        String existingIsbn = "100";
+        Mockito.doNothing().when(eBookRepository).deleteEBook(existingIsbn);
+
+        // When
+        deleteEBookUseCase.execute(existingIsbn);
+
+        // Then
+        Mockito.verify(eBookRepository, Mockito.times(1)).deleteEBook(existingIsbn);
+    }
+
+    @Test
+    public void givingAnInvalidIsbnThenDoesNotDeleteAnyEBook(){
+        //Given
+        String invalidIsbn = "";
+        Mockito.doNothing().when(eBookRepository).deleteEBook(invalidIsbn);
+
+        //When
+        deleteEBookUseCase.execute(invalidIsbn);
+
+        //Then
+        Mockito.verify(eBookRepository, Mockito.times(1)).deleteEBook(invalidIsbn);
+    }
+
+    @Test
+    public void givingNullIsbnThenNeverDeleteAnyEBook() {
+        // Given
+        String nullIsbn = null;
+
+        // When
+        deleteEBookUseCase.execute(nullIsbn);
+
+        // Then
+        Mockito.verify(eBookRepository, Mockito.never()).deleteEBook(Mockito.anyString());
+    }
+
+}

--- a/src/test/java/com/iesam/digitallibrary/features/ebook/domain/GetEBookUseCaseTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/ebook/domain/GetEBookUseCaseTest.java
@@ -1,0 +1,90 @@
+package com.iesam.digitallibrary.features.ebook.domain;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetEBookUseCaseTest {
+    @Mock
+    EBookRepository eBookRepository;
+
+    GetEBookUseCase getEBookUseCase;
+
+    @BeforeEach
+    void setUp() {
+        getEBookUseCase = new GetEBookUseCase(eBookRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        getEBookUseCase = null;
+    }
+
+    @Test
+    public void givingAValidIdThenReturnAnEBook(){
+        //Given
+        EBook eBookExpected = new EBook("100", "Title", "Author", "Comedy", "2024", "English");
+        Mockito.when(eBookRepository.getEBook("100")).thenReturn(eBookExpected);
+
+        //When
+        EBook eBookReceived = getEBookUseCase.execute("100");
+
+        //Then
+        Assertions.assertEquals(eBookReceived.isbn, "100");
+        Assertions.assertEquals(eBookReceived.title, "Title");
+        Assertions.assertEquals(eBookReceived.author, "Author");
+        Assertions.assertEquals(eBookReceived.genre, "Comedy");
+        Assertions.assertEquals(eBookReceived.publicationYear, "2024");
+        Assertions.assertEquals(eBookReceived.language, "English");
+    }
+
+    @Test
+    public void givingANonValidIsbnThenReturnNull(){
+        //Given
+        Mockito.when(eBookRepository.getEBook("")).thenReturn(null);
+
+        //When
+        EBook eBookReceived = getEBookUseCase.execute("");
+
+        //Then
+        Assertions.assertNull(eBookReceived);
+        Mockito.verify(eBookRepository, Mockito.times(1)).getEBook("");
+
+    }
+
+    @Test
+    public void givingANullIsbnThenReturnNull(){
+        //Given
+        Mockito.when(eBookRepository.getEBook(null)).thenReturn(null);
+
+        //When
+        EBook eBookReceived = getEBookUseCase.execute(null);
+
+        //Then
+        Assertions.assertNull(eBookReceived);
+        Mockito.verify(eBookRepository, Mockito.times(1)).getEBook(null);
+    }
+    @Test
+    public void testGetEBookCallsRepository() {
+        // Given
+        String eBookId = "123";
+        EBook expectedEBook = new EBook(eBookId, "Title", "Author", "Fiction", "2024", "English");
+        Mockito.when(eBookRepository.getEBook(eBookId)).thenReturn(expectedEBook);
+
+        // When
+        EBook eBook = getEBookUseCase.execute(eBookId);
+
+        // Then
+        Mockito.verify(eBookRepository, Mockito.times(1)).getEBook(eBookId);
+        Assertions.assertEquals(expectedEBook, eBook);
+    }
+
+}

--- a/src/test/java/com/iesam/digitallibrary/features/ebook/domain/ListEbooksUseCaseTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/ebook/domain/ListEbooksUseCaseTest.java
@@ -1,0 +1,80 @@
+package com.iesam.digitallibrary.features.ebook.domain;
+
+import com.iesam.digitallibrary.features.user.domain.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class ListEbooksUseCaseTest {
+
+    @Mock
+    EBookRepository eBookRepository;
+
+    ListEbooksUseCase listEbooksUseCase;
+
+    @BeforeEach
+    void setUp() {
+        listEbooksUseCase = new ListEbooksUseCase(eBookRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        listEbooksUseCase = null;
+    }
+
+    @Test
+    public void ifExistsEBooksThenReturnTheEBookList(){
+        //Given
+        EBook eBook1 = new EBook("100","Title1", "Author1", "Comedy", "2024","Spanish");
+        EBook eBook2 = new EBook("200","Title2", "Author2", "Fiction", "2024","Spanish");
+        Mockito.when(eBookRepository.getEBooks()).thenReturn(List.of(eBook1, eBook2));
+
+        //When
+        List<EBook> eBooks = listEbooksUseCase.execute();
+
+        //Then
+        Assertions.assertFalse(eBooks.isEmpty());
+        Assertions.assertEquals(2, eBooks.size());
+        Assertions.assertTrue(eBooks.contains(eBook1));
+        Assertions.assertTrue(eBooks.contains(eBook2));
+    }
+
+    @Test
+    public void ifTheEBookListIsEmptyThenReturnAnEmptyList(){
+        //Given
+        Mockito.when(eBookRepository.getEBooks()).thenReturn(Collections.emptyList());
+
+        //When
+        List<EBook> eBookList = listEbooksUseCase.execute();
+
+        //Then
+        Assertions.assertTrue(eBookList.isEmpty());
+    }
+
+    @Test
+    public void ifExistsSingleEBookThenReturnTheSingleEBookList() {
+        // Given
+        EBook eBook = new EBook("100", "Title1", "Author1", "Comedy", "2024", "Spanish");
+        Mockito.when(eBookRepository.getEBooks()).thenReturn(List.of(eBook));
+
+        // When
+        List<EBook> eBooks = listEbooksUseCase.execute();
+
+        // Then
+        Assertions.assertFalse(eBooks.isEmpty());
+        Assertions.assertEquals(1, eBooks.size());
+        Assertions.assertTrue(eBooks.contains(eBook));
+        Mockito.verify(eBookRepository,Mockito.times(1)).getEBooks();
+    }
+}

--- a/src/test/java/com/iesam/digitallibrary/features/ebook/domain/NewEBookUseCaseTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/ebook/domain/NewEBookUseCaseTest.java
@@ -1,0 +1,54 @@
+package com.iesam.digitallibrary.features.ebook.domain;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class NewEBookUseCaseTest {
+
+    @Mock
+    EBookRepository eBookRepository;
+
+    NewEBookUseCase newEBookUseCase;
+
+    @BeforeEach
+    void setUp() {
+        newEBookUseCase = new NewEBookUseCase(eBookRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        newEBookUseCase = null;
+    }
+
+    @Test
+    public void receiveAnEBookAndSaveIt(){
+        //Given
+        EBook eBookToSave = new EBook("100", "Title", "Author", "Comedy", "2024", "English");
+
+        //When
+        newEBookUseCase.execute(eBookToSave);
+
+        //Then
+        Mockito.verify(eBookRepository, Mockito.times(1)).createEBook(eBookToSave);
+    }
+
+    @Test
+    public void ifEBookIsNullThenNeverCreateNewEBook(){
+        //Given
+        EBook nullEBook = null;
+
+        //When
+        newEBookUseCase.execute(nullEBook);
+
+        //Then
+        Mockito.verify(eBookRepository, Mockito.never()).createEBook(Mockito.any(EBook.class));
+    }
+}

--- a/src/test/java/com/iesam/digitallibrary/features/ebook/domain/UpdateEBookUseCaseTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/ebook/domain/UpdateEBookUseCaseTest.java
@@ -1,0 +1,58 @@
+package com.iesam.digitallibrary.features.ebook.domain;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateEBookUseCaseTest {
+
+    @Mock
+    EBookRepository eBookRepository;
+
+    UpdateEBookUseCase updateEBookUseCase;
+
+    @BeforeEach
+    void setUp() {
+        updateEBookUseCase = new UpdateEBookUseCase(eBookRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        updateEBookUseCase = null;
+    }
+
+    @Test
+    public void ifIsbnExistThenUpdateUser() {
+        //Given
+        EBook updatedEbook = new EBook("100", "Title", "Author", "Romance", "2024", "French");
+        Mockito.doNothing().when(eBookRepository).updateEBook(Mockito.any(EBook.class));
+
+        //When
+        updateEBookUseCase.execute(updatedEbook);
+
+        //Then
+        Mockito.verify(eBookRepository, Mockito.times(1)).updateEBook(Mockito.any(EBook.class));
+    }
+
+    @Test
+    public void ifEBookIsNullThenNoUpdateEBook() {
+        //Given
+        EBook nullEBook = null;
+
+        //When
+        updateEBookUseCase.execute(nullEBook);
+
+        //Then
+        Mockito.verify(eBookRepository, Mockito.never()).updateEBook(Mockito.any(EBook.class));
+    }
+
+}

--- a/src/test/java/com/iesam/digitallibrary/features/user/domain/GetUserUseCaseTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/user/domain/GetUserUseCaseTest.java
@@ -62,11 +62,10 @@ class GetUserUseCaseTest {
     @Test
     public void givingAnIdNotValidThenReturnNull(){
         //Given
-        String userIdNotValid = "200";
-        Mockito.when(userRepository.getUser("200")).thenReturn(null);
+        Mockito.when(userRepository.getUser("")).thenReturn(null);
 
         //When
-        User userReceived = getUserUseCase.execute("200");
+        User userReceived = getUserUseCase.execute("");
 
         //Then
         Assertions.assertNull(userReceived);
@@ -80,10 +79,10 @@ class GetUserUseCaseTest {
     public void ifUserIdIsNullThenReturnNull(){
         //Given
         String userIdNull = null;
-        Mockito.when(getUserUseCase.execute(null)).thenReturn(null);
+        Mockito.when(getUserUseCase.execute(userIdNull)).thenReturn(null);
 
         //When
-        User userReceived = getUserUseCase.execute(null);
+        User userReceived = getUserUseCase.execute(userIdNull);
 
         //Then
         Assertions.assertNull(userReceived);


### PR DESCRIPTION

#31

## 📝 Breve descripción del ticket asociado a esta PR

Esta pull request está asociada con el ticket de implementación de tests unitarios para todas las funcionalidades de `EBook` en el proyecto de la biblioteca digital. 

## 👩‍💻 Resumen de los cambios introducidos

Se han añadido tests unitarios para las siguientes funcionalidades de `EBook`:

- **NewEBookUseCaseTest (Crear EBook)**:
  - **`receiveAnEBookAndSaveIt`**: Verificación de la creación correcta de un nuevo `EBook`.
  - **`ifEBookIsNullThenNeverCreateNewEBook`**: Confirmación de que no se crea un `EBook` si el objeto proporcionado es `null`.

- **GetEBookUseCaseTest (Obtener EBook)**:
  - **`givingAValidIdThenReturnAnEBook`**: Verificación de la obtención correcta de un `EBook` por su ISBN.
  - **`givingANonValidIsbnThenReturnNull`**: Confirmación de que se devuelve `null` si se proporciona un ISBN no válido.
  - **`givingANullIsbnThenReturnNull`**: Confirmación de que se devuelve `null` si se proporciona un ISBN `null`.
  - **`testGetEBookCallsRepository`**: Confirmación de que se invoca el método `getEBook` con el ISBN correcto.

- **ListEbooksUseCaseTest (Listar EBooks)**:
  - **`ifExistsEBooksThenReturnTheEBookList`**: Verificación de que se obtienen correctamente todos los `EBooks`.
  - **`ifTheEBookListIsEmptyThenReturnAnEmptyList`**: Confirmación de que se devuelve una lista vacía si no hay `EBooks`.
  - **`ifExistsSingleEBookThenReturnTheSingleEBookList`**: Confirmación de que se devuelve correctamente una lista con un solo `EBook`.

- **DeleteEBookUseCaseTest (Eliminar EBook)**:
  - **`deletingAnExistingEBookByIsbn`**: Verificación de la eliminación correcta de un `EBook` por su ISBN.
  - **`givingAnInvalidIsbnThenDoesNotDeleteAnyEBook`**: Confirmación de que no se elimina ningún `EBook` si se proporciona un ISBN no válido.
  - **`givingNullIsbnThenNeverDeleteAnyEBook`**: Confirmación de que no se elimina ningún `EBook` si se proporciona un ISBN `null`.

- **UpdateEBookUseCaseTest (Actualizar EBook)**:
  - **`ifIsbnExistThenUpdateUser`**: Verificación de la actualización correcta de un `EBook` cuando el ISBN existe.
  - **`ifEBookIsNullThenNoUpdateEBook`**: Confirmación de que no se actualiza ningún `EBook` cuando el objeto proporcionado es `null`.

## 👁️ Partes del código que deben ser revisadas con más atención

- **NewEBookUseCaseTest**: Asegurarse de que el test comprueba correctamente que el `EBook` se guarda en el repositorio.
- **GetEBookUseCaseTest**: Revisar que la lógica de obtención por ISBN funciona correctamente y que se manejan adecuadamente los casos de ISBN no válidos o `null`.
- **ListEbooksUseCaseTest**: Confirmar que se está verificando la correcta obtención de la lista completa de `EBooks`, incluyendo casos con lista vacía o lista con un solo elemento.
- **DeleteEBookUseCaseTest**: Verificar que el `EBook` se elimina correctamente y que no se intenta eliminar un `EBook` inexistente o con ISBN `null`.
- **UpdateEBookUseCaseTest**: Asegurarse de que se cubren todos los casos posibles (EBook existente, EBook `null`) y que las interacciones con el repositorio son correctas.

## 📸 Screenshot o Video
**NewEBook**
![image](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/09c23e5a-5c37-4c3b-a0a3-dc6486bb6a15)

**GetEBook**
![image](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/ad9afac2-2275-4355-b50a-ef6908e9b775)

**ListEBooks*
![image](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/44f4ad4a-dbe9-458d-a688-abc8aea04fcd)

**DeleteEBook**
![image](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/1a18c6fe-bfc9-4c63-87c0-dfa10d18986a)

**UpdateEBook**
![image](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/93bb5b8e-b0a9-4541-b030-d02bcb636704)

---

## ✅ Checklist
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] El proyecto compila y se ejecuta correctamente.
- [x] El código se ha probado con todas las opciones posibles.
- [x] El código ha sido formateado.
- [x] He eliminado código de prueba.
- [x] Se han añadido test unitarios.

## ✋ Notas adicionales (Disclaimer)

Se ha llevado a cabo una pequeña actualización en el código de `GetUserUseCaseTest`, que no consideraba suficiente para hacer una pull request a parte

## 🌈 Añade un Gif que represente a esta PR

![walfa-koakuma-books](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/32c203b9-135f-4918-b7f5-4e8d7fa633b2)
