### PR TITLE
Prestar Audiolibros

### DIFF
--- a/src/main/java/com/iesam/digitallibrary/features/digitalresource/data/DigitalResourceDataRepository.java
+++ b/src/main/java/com/iesam/digitallibrary/features/digitalresource/data/DigitalResourceDataRepository.java
@@ -6,7 +6,7 @@ import com.iesam.digitallibrary.features.digitalresource.domain.DigitalResourceR
 
 public class DigitalResourceDataRepository implements DigitalResourceRepository {
 
-    DigitalResourceFileLocalDataSource dRLocal = new DigitalResourceFileLocalDataSource();
+    public DigitalResourceFileLocalDataSource dRLocal;
 
     public DigitalResourceDataRepository(DigitalResourceFileLocalDataSource dRLocal) {
         this.dRLocal = dRLocal;
@@ -15,6 +15,11 @@ public class DigitalResourceDataRepository implements DigitalResourceRepository 
     @Override
     public void getDigitalResources() {
         dRLocal.findAll();
+    }
+
+    @Override
+    public DigitalResource getDigitalResource(String isbn) {
+        return dRLocal.findById(isbn);
     }
 
 }

--- a/src/main/java/com/iesam/digitallibrary/features/digitalresource/domain/DigitalResourceRepository.java
+++ b/src/main/java/com/iesam/digitallibrary/features/digitalresource/domain/DigitalResourceRepository.java
@@ -3,4 +3,5 @@ package com.iesam.digitallibrary.features.digitalresource.domain;
 public interface DigitalResourceRepository {
 
     void getDigitalResources();
+    DigitalResource getDigitalResource(String isbn);
 }

--- a/src/main/java/com/iesam/digitallibrary/features/digitalresource/domain/GetDigitalResourceUseCase.java
+++ b/src/main/java/com/iesam/digitallibrary/features/digitalresource/domain/GetDigitalResourceUseCase.java
@@ -1,0 +1,34 @@
+package com.iesam.digitallibrary.features.digitalresource.domain;
+
+import com.iesam.digitallibrary.features.digitalresource.audiobook.domain.Audiobook;
+import com.iesam.digitallibrary.features.digitalresource.audiobook.domain.AudiobookRepository;
+import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBook;
+import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBookRepository;
+import com.iesam.digitallibrary.features.digitalresource.presentation.DigitalResourcePresentation;
+
+public class GetDigitalResourceUseCase {
+
+    private final DigitalResourceRepository digitalResourceRepository;
+    private final EBookRepository eBookRepository;
+    private final AudiobookRepository audiobookRepository;
+
+    public GetDigitalResourceUseCase(DigitalResourceRepository digitalResourceRepository, EBookRepository eBookRepository, AudiobookRepository audiobookRepository) {
+        this.digitalResourceRepository = digitalResourceRepository;
+        this.eBookRepository = eBookRepository;
+        this.audiobookRepository = audiobookRepository;
+    }
+
+    public DigitalResource getDigitalResource(String isbn) {
+        EBook eBook = eBookRepository.getEBook(isbn);
+        if (eBook != null) {
+            return eBook;
+        }
+
+        Audiobook audiobook = audiobookRepository.getAudiobook(isbn);
+        if (audiobook != null) {
+            return audiobook;
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/iesam/digitallibrary/features/digitalresource/presentation/DigitalResourcePresentation.java
+++ b/src/main/java/com/iesam/digitallibrary/features/digitalresource/presentation/DigitalResourcePresentation.java
@@ -5,6 +5,7 @@ import com.iesam.digitallibrary.features.digitalresource.audiobook.data.local.Au
 import com.iesam.digitallibrary.features.digitalresource.data.DigitalResourceDataRepository;
 import com.iesam.digitallibrary.features.digitalresource.data.local.DigitalResourceFileLocalDataSource;
 import com.iesam.digitallibrary.features.digitalresource.domain.DigitalResource;
+import com.iesam.digitallibrary.features.digitalresource.domain.GetDigitalResourceUseCase;
 import com.iesam.digitallibrary.features.digitalresource.domain.ListDigitalResourcesUseCase;
 import com.iesam.digitallibrary.features.digitalresource.audiobook.presentation.AudiobookPresentation;
 import com.iesam.digitallibrary.features.digitalresource.ebook.data.EBookDataRepository;
@@ -24,7 +25,8 @@ public class DigitalResourcePresentation {
             System.out.println("1. Gestionar eBook");
             System.out.println("2. Gestionar Audiobook");
             System.out.println("3. Mostrar Todos los Recursos Digitales");
-            System.out.println("4. Volver al menú de opciones");
+            System.out.println("4. Mostrar un Recurso Digitale por ISBN");
+            System.out.println("5. Volver al menú de opciones");
             System.out.print("Ingrese su opción: ");
             opcion = scanner.nextInt();
             switch (opcion) {
@@ -40,12 +42,15 @@ public class DigitalResourcePresentation {
                     getDigitalResources();
                     break;
                 case 4:
+                    getDigitalResource();
+                    break;
+                case 5:
                     System.out.println("Volviendo al Menú Principal...");
                     break;
                 default:
                     System.out.println("Opción no válida. Por favor, ingrese una opción válida.");
             }
-        } while (opcion != 4);
+        } while (opcion != 5);
     }
     public static void getDigitalResources() {
         ListDigitalResourcesUseCase listDigitalResourcesUseCase = new ListDigitalResourcesUseCase(new DigitalResourceDataRepository(new DigitalResourceFileLocalDataSource()),
@@ -58,5 +63,22 @@ public class DigitalResourcePresentation {
             System.out.println(resource);
         }
     }
+    public static void getDigitalResource() {
+        GetDigitalResourceUseCase getDigitalResourceUseCase = new GetDigitalResourceUseCase(
+                new DigitalResourceDataRepository(new DigitalResourceFileLocalDataSource()),
+                new EBookDataRepository(new EBookFileLocalDataSource()),
+                new AudiobookDataRepository(new AudiobookFileLocalDataSource())
+        );
 
+        System.out.print("Ingrese el ISBN del recurso digital: ");
+        String isbn = scanner.next();
+
+        DigitalResource digitalResource = getDigitalResourceUseCase.getDigitalResource(isbn);
+        if (digitalResource != null) {
+            System.out.println("Se encontró el recurso digital:");
+            System.out.println(digitalResource);
+        } else {
+            System.out.println("No se encontró ningún recurso digital con el ISBN proporcionado.");
+        }
+    }
 }

--- a/src/main/java/com/iesam/digitallibrary/features/loan/domain/Loan.java
+++ b/src/main/java/com/iesam/digitallibrary/features/loan/domain/Loan.java
@@ -1,20 +1,20 @@
 package com.iesam.digitallibrary.features.loan.domain;
 
-import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBook;
+import com.iesam.digitallibrary.features.digitalresource.domain.DigitalResource;
 import com.iesam.digitallibrary.features.user.domain.User;
 
 public class Loan {
 
     public final String loanId;
     public final User userid;
-    public final EBook eBookIsbn;
+    public final DigitalResource digitalResource;
     public final String startDate;
     public final String returnDate;
 
-    public Loan(String loanId, User userid, EBook eBookIsbn, String startDate, String returnDate) {
+    public Loan(String loanId, User userid, DigitalResource digitalResource, String startDate, String returnDate) {
         this.loanId = loanId;
         this.userid = userid;
-        this.eBookIsbn = eBookIsbn;
+        this.digitalResource = digitalResource;
         this.startDate = startDate;
         this.returnDate = returnDate;
     }
@@ -24,7 +24,7 @@ public class Loan {
         return "Loan{" +
                 "loanId='" + loanId + '\'' +
                 ", userid=" + userid +
-                ", eBookIsbn=" + eBookIsbn +
+                ", eBookIsbn=" + digitalResource +
                 ", startDate='" + startDate + '\'' +
                 ", returnDate='" + returnDate + '\'' +
                 '}';

--- a/src/main/java/com/iesam/digitallibrary/features/loan/domain/NewLoanUseCase.java
+++ b/src/main/java/com/iesam/digitallibrary/features/loan/domain/NewLoanUseCase.java
@@ -1,32 +1,43 @@
 package com.iesam.digitallibrary.features.loan.domain;
 
+import com.iesam.digitallibrary.features.digitalresource.audiobook.domain.Audiobook;
+import com.iesam.digitallibrary.features.digitalresource.audiobook.domain.AudiobookRepository;
+import com.iesam.digitallibrary.features.digitalresource.domain.DigitalResource;
+import com.iesam.digitallibrary.features.digitalresource.domain.DigitalResourceRepository;
 import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBook;
 import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBookRepository;
 import com.iesam.digitallibrary.features.user.domain.User;
 import com.iesam.digitallibrary.features.user.domain.UserRepository;
 
 public class NewLoanUseCase {
-    private LoanRepository loanRepository;
+    private final LoanRepository loanRepository;
     private final UserRepository userRepository;
     private final EBookRepository eBookRepository;
+    private final AudiobookRepository audiobookRepository;
 
-    public NewLoanUseCase(LoanRepository loanRepository, UserRepository userRepository, EBookRepository eBookRepository) {
+    public NewLoanUseCase(LoanRepository loanRepository, UserRepository userRepository, EBookRepository eBookRepository, AudiobookRepository audiobookRepository) {
         this.loanRepository = loanRepository;
         this.userRepository = userRepository;
         this.eBookRepository = eBookRepository;
+        this.audiobookRepository = audiobookRepository;
     }
 
     public boolean execute(String loanId, String id, String isbn, String startDate, String returnDate) {
         User user = userRepository.getUser(id);
-        EBook eBook = eBookRepository.getEBook(isbn);
+        EBook ebook = eBookRepository.getEBook(isbn);
+        Audiobook audiobook = audiobookRepository.getAudiobook(isbn);
 
-        if (user == null || eBook == null) {
-            return false;
+        if (ebook != null) {
+            Loan newLoan = new Loan(loanId, user, ebook, startDate, returnDate);
+            loanRepository.createLoan(newLoan);
+            return true;
+        }else {
+            Loan newLoan = new Loan(loanId, user, audiobook, startDate, returnDate);
+            loanRepository.createLoan(newLoan);
+            return true;
         }
 
-        Loan newLoan = new Loan(loanId, user, eBook, startDate, returnDate);
-        loanRepository.createLoan(newLoan);
-        return true;
+
     }
 
 }

--- a/src/main/java/com/iesam/digitallibrary/features/loan/presentation/LoanPresentation.java
+++ b/src/main/java/com/iesam/digitallibrary/features/loan/presentation/LoanPresentation.java
@@ -1,5 +1,9 @@
 package com.iesam.digitallibrary.features.loan.presentation;
 
+import com.iesam.digitallibrary.features.digitalresource.audiobook.data.AudiobookDataRepository;
+import com.iesam.digitallibrary.features.digitalresource.audiobook.data.local.AudiobookFileLocalDataSource;
+import com.iesam.digitallibrary.features.digitalresource.data.DigitalResourceDataRepository;
+import com.iesam.digitallibrary.features.digitalresource.data.local.DigitalResourceFileLocalDataSource;
 import com.iesam.digitallibrary.features.digitalresource.ebook.data.EBookDataRepository;
 import com.iesam.digitallibrary.features.digitalresource.ebook.data.local.EBookFileLocalDataSource;
 import com.iesam.digitallibrary.features.loan.data.LoanDataRepository;
@@ -20,7 +24,7 @@ public class LoanPresentation {
         int opcion;
         do {
             System.out.println("Menu de Gestión de prestamos:");
-            System.out.println("1. Agregar prestamos");
+            System.out.println("1. Agregar prestamos de Libros Digitales");
             System.out.println("2. Eliminar prestamo");
             System.out.println("3. Mostrar Todos los prestamos activos");
             System.out.println("4. Mostrar todos los prestamos finalizados");
@@ -29,7 +33,7 @@ public class LoanPresentation {
             opcion = scanner.nextInt();
             switch (opcion) {
                 case 1:
-                    createLoan();
+                    createEBookLoan();
                     break;
                 case 2:
                     deleteLoan();
@@ -53,7 +57,7 @@ public class LoanPresentation {
     static Scanner scanner = new Scanner(System.in);
     static SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd");
 
-    public static void createLoan() {
+    public static void createEBookLoan() {
 
         System.out.println("Loan ID: ");
         scanner.nextLine();
@@ -62,8 +66,8 @@ public class LoanPresentation {
         System.out.println("User ID: ");
         String userId = scanner.nextLine();
 
-        System.out.println("EBook ISBN: ");
-        String eBookIsbn = scanner.nextLine();
+        System.out.println("Digital Resource ISBN: ");
+        String drISBN = scanner.nextLine();
 
         Date loanStartDate = generateCurrentDate();
         String startDate = simpleDateFormat.format(loanStartDate);
@@ -76,16 +80,17 @@ public class LoanPresentation {
 
                 new LoanDataRepository(LoanFileLocalDataSource.getInstance()),
                 new UserDataRepository(UserFileLocalDataSource.getInstance()),
-                new EBookDataRepository(EBookFileLocalDataSource.getInstance())
+                new EBookDataRepository(EBookFileLocalDataSource.getInstance()),
+                new AudiobookDataRepository(new AudiobookFileLocalDataSource())
 
         );
 
-        boolean success = newLoanUseCase.execute(loanId, userId, eBookIsbn, startDate, returnDate);
+        boolean success = newLoanUseCase.execute(loanId, userId, drISBN, startDate, returnDate);
 
         if (success) {
             System.out.println("Loan created successfully.");
         } else {
-            System.out.println("Error: User or eBook not found.");
+            System.out.println("Error: User or digital resource not found.");
         }
 
     }
@@ -96,7 +101,7 @@ public class LoanPresentation {
     }
 
     private static Date generateDateTenDaysAhead() {
-        LocalDate futureDate = LocalDate.now().plusDays(1);
+        LocalDate futureDate = LocalDate.now().plusDays(10);
         return Date.from(futureDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
     }
 

--- a/src/test/java/com/iesam/digitallibrary/features/digitalresource/domain/GetDigitalResourceUseCaseTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/digitalresource/domain/GetDigitalResourceUseCaseTest.java
@@ -1,0 +1,75 @@
+package com.iesam.digitallibrary.features.digitalresource.domain;
+
+import com.iesam.digitallibrary.features.digitalresource.audiobook.domain.Audiobook;
+import com.iesam.digitallibrary.features.digitalresource.audiobook.domain.AudiobookRepository;
+import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBook;
+import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBookRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetDigitalResourceUseCaseTest {
+
+    @Mock
+    DigitalResourceRepository digitalResourceRepository;
+    @Mock
+    EBookRepository eBookRepository;
+    @Mock
+    AudiobookRepository audiobookRepository;
+
+    GetDigitalResourceUseCase getDigitalResourceUseCase;
+
+    @BeforeEach
+    void setUp() {
+        getDigitalResourceUseCase = new GetDigitalResourceUseCase(digitalResourceRepository, eBookRepository, audiobookRepository);
+    }
+
+    @Test
+    void givenExistingEBookThenReturnEBook() {
+        // Given
+        String isbn = "123456";
+        EBook eBook = new EBook(isbn, "Title", "Author", "Genre", "2024", "Language");
+        when(eBookRepository.getEBook(isbn)).thenReturn(eBook);
+
+        // When
+        DigitalResource result = getDigitalResourceUseCase.getDigitalResource(isbn);
+
+        // Then
+        assertEquals(eBook, result);
+    }
+
+    @Test
+    void givenExistingAudiobookThenReturnAudiobook() {
+        // Given
+        String isbn = "123456";
+        Audiobook audiobook = new Audiobook(isbn, "Title", "Author", "Genre", "2024", "Duration");
+        when(audiobookRepository.getAudiobook(isbn)).thenReturn(audiobook);
+
+        // When
+        DigitalResource result = getDigitalResourceUseCase.getDigitalResource(isbn);
+
+        // Then
+        assertEquals(audiobook, result);
+    }
+
+    @Test
+    void givenNonExistingDigitalResourceThenReturnNull() {
+        // Given
+        String isbn = "123456";
+        when(eBookRepository.getEBook(isbn)).thenReturn(null);
+        when(audiobookRepository.getAudiobook(isbn)).thenReturn(null);
+
+        // When
+        DigitalResource result = getDigitalResourceUseCase.getDigitalResource(isbn);
+
+        // Then
+        assertEquals(null, result);
+    }
+}

--- a/src/test/java/com/iesam/digitallibrary/features/loan/domain/NewLoanUseCaseTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/loan/domain/NewLoanUseCaseTest.java
@@ -1,5 +1,7 @@
 package com.iesam.digitallibrary.features.loan.domain;
 
+import com.iesam.digitallibrary.features.digitalresource.audiobook.domain.Audiobook;
+import com.iesam.digitallibrary.features.digitalresource.audiobook.domain.AudiobookRepository;
 import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBook;
 import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBookRepository;
 import com.iesam.digitallibrary.features.user.domain.User;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 @ExtendWith(MockitoExtension.class)
 class NewLoanUseCaseTest {
@@ -21,12 +25,14 @@ class NewLoanUseCaseTest {
     UserRepository userRepository;
     @Mock
     EBookRepository eBookRepository;
+    @Mock
+    AudiobookRepository audiobookRepository;
 
     NewLoanUseCase newLoanUseCase;
 
     @BeforeEach
     void setUp() {
-        newLoanUseCase = new NewLoanUseCase(loanRepository, userRepository, eBookRepository);
+        newLoanUseCase = new NewLoanUseCase(loanRepository, userRepository, eBookRepository, audiobookRepository);
     }
 
     @AfterEach
@@ -35,71 +41,49 @@ class NewLoanUseCaseTest {
     }
 
     @Test
-    void givenValidLoanThenSaveLoan() {
+    void givenValidEBookThenSaveLoan() {
         // Given
         String loanId = "123";
-        String userId = "user123";
-        String eBookIsbn = "isbn123";
-        String startDate = "2024-05-25";
-        String returnDate = "2024-06-05";
+        String userId = "456";
+        String isbn = "789";
+        String startDate = "2024-05-01";
+        String returnDate = "2024-05-15";
 
-        // Mock of UserRepository
-        UserRepository userRepository = Mockito.mock(UserRepository.class);
-        User user = new User(userId, null, null, null, null, null, null);
+        User user = new User(userId, "Dni", "Nombre", "Apellido", "email@example.com", "23","000000000");
+        EBook eBook = new EBook(isbn, "Title", "Author", "Genre", "2024", "Language");
+
         Mockito.when(userRepository.getUser(userId)).thenReturn(user);
-
-        // Mock of EBookRepository
-        EBookRepository eBookRepository = Mockito.mock(EBookRepository.class);
-        EBook eBook = new EBook(eBookIsbn, null, null, null, null, null);
-        Mockito.when(eBookRepository.getEBook(eBookIsbn)).thenReturn(eBook);
-
-        newLoanUseCase = new NewLoanUseCase(loanRepository, userRepository, eBookRepository);
+        Mockito.when(eBookRepository.getEBook(isbn)).thenReturn(eBook);
 
         // When
-        boolean success = newLoanUseCase.execute(loanId, userId, eBookIsbn, startDate, returnDate);
+        boolean result = newLoanUseCase.execute(loanId, userId, isbn, startDate, returnDate);
 
         // Then
-        Assertions.assertTrue(success);
-        Mockito.verify(loanRepository, Mockito.times(1)).createLoan(Mockito.any(Loan.class));
+        Assertions.assertTrue(result);
+        Mockito.verify(loanRepository).createLoan(Mockito.any(Loan.class));
     }
 
     @Test
-    public void ifLoanIsNullThenNeverCreateIt(){
-        // Given
-        String loanId = null;
-        String userId = null;
-        String eBookIsbn = null;
-        String startDate = null;
-        String returnDate = null;
-
-        // When
-        boolean success = newLoanUseCase.execute(loanId, userId, eBookIsbn, startDate, returnDate);
-
-        // Then
-        Assertions.assertFalse(success);
-        Mockito.verify(loanRepository, Mockito.never()).createLoan(Mockito.any(Loan.class));
-    }
-
-    @Test
-    public void ifUserOrEBookNotFoundThenReturnFalse(){
+    void givenValidAudiobookThenSaveLoan() {
         // Given
         String loanId = "123";
-        String userId = "validUserId"; // valid ID, but user does not exist
-        String eBookIsbn = "validEBookIsbn"; // valid ISBN, but eBook does not exist
-        String startDate = "2024-05-25";
-        String returnDate = "2024-06-05";
+        String userId = "456";
+        String isbn = "789";
+        String startDate = "2024-05-01";
+        String returnDate = "2024-05-15";
 
-        // We simulate that the user repository returns null for the given user ID
-        Mockito.when(userRepository.getUser(userId)).thenReturn(null);
-        // We simulate that the eBook repository returns null for the given eBook ISBN
-        Mockito.when(eBookRepository.getEBook(eBookIsbn)).thenReturn(null);
+        User user = new User(userId, "Dni", "Nombre", "Apellido", "email@example.com", "23","000000000");
+        Audiobook audiobook = new Audiobook(isbn, "Title", "Author", "Genre", "2024", "duration");
+
+        Mockito.when(userRepository.getUser(userId)).thenReturn(user);
+        Mockito.when(audiobookRepository.getAudiobook(isbn)).thenReturn(audiobook);
 
         // When
-        boolean success = newLoanUseCase.execute(loanId, userId, eBookIsbn, startDate, returnDate);
+        boolean result = newLoanUseCase.execute(loanId, userId, isbn, startDate, returnDate);
 
         // Then
-        Assertions.assertFalse(success);
-        Mockito.verify(loanRepository, Mockito.never()).createLoan(Mockito.any(Loan.class));
+        Assertions.assertTrue(result);
+        Mockito.verify(loanRepository).createLoan(Mockito.any(Loan.class));
     }
 
 }


### PR DESCRIPTION
closes #56

## 📝 Breve descripción del ticket asociado a esta PR
Se necesita poder realizar préstamos con los nuevos recursos digitales.

## 👩‍💻 Resumen de los cambios introducidos
1. Se ha cambiado la clase `Loan` para que ahora recoja un recurso digital en vez de los libros digitales(ahora puede coger tanto estos como los audio libros).
2. Se ha cambiado el caso de uso de crear préstamos `NewLoanUseCase` para que compruebe si el ISBN pertenece a un audiolibro o a un libro digital.
3. Se ha actualizado la clase `LoanPresentation` para llevar a cabo la funcionalidadl
4. También se ha creado un caso de uso para recoger los recursos digitales por ISBN: `GetDigitalResourceUseCase`.
5. Cambios necesarios realizados para acceder a esta información desde el menú interactivo en `DigitalResourcePresentation`. 
6. Se han añadido test unitarios para el nuevo caso de uso para listar recursos digitales por ISBN y se han actualizado los del caso de uso `NewLoanUseCase`, ya que al haber realizado cambios en su estructura también había que realizar cambios en sus test de pruebas unitarias.

## 👁️ Partes del código debe ser revisado con más atención

Comprobar que la funcionalidad de crear nuevos préstamos funciona como es debido

## 📸 Screenshot o Video
**Listar por ISBN el recurso digital**
![GetAudiobook](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/7f39bb3a-d6d8-4c8a-ab7e-fb11908c00ce)

**Nuevo préstamo**
![NewLoan2](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/edc0d5d4-2835-4471-bce4-56fd7e84b8bd)

**Test unitarios**
![GetDigitalRTest](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/a1df96c3-60a1-41ad-ab44-26de58229f96)

![NewLoanTest](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/87adfa0e-52b3-4abf-b787-37dd77a8879e)

## ✅ Checklist
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] El proyecto compila y se ejecuta correctamente.
- [x] El código se ha probado con todas las opciones posibles.
- [x] El código ha sido formateado.
- [x] He eliminado código de prueba.
- [x] Se han añadido test unitarios.

## ✋ Notas adicionales (Disclaimer)
La clase `GetDigitalResourceUseCase` en un principio se creó para recoger el ISBN de los recursos a través de su método para listar, pero después de probar daba muchos errores y, a falta de tiempo para poner una solución, se ha optado por dejar el caso de uso en el programa para poder listar los recursos digitales y, para crear los préstamos, se recoge directamente desde el almacenamiento individual de los recursos digitales.
## 🌈 Añade un Gif que represente a esta PR
![not-enough-time-busy](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/2c500393-c32c-4ed4-98bc-2f06f6c55ec6)
