### PR TITLE
Test de Capas de Datos

### DIFF
--- a/src/main/java/com/iesam/digitallibrary/features/digitalresource/data/DigitalResourceDataRepository.java
+++ b/src/main/java/com/iesam/digitallibrary/features/digitalresource/data/DigitalResourceDataRepository.java
@@ -4,6 +4,8 @@ import com.iesam.digitallibrary.features.digitalresource.data.local.DigitalResou
 import com.iesam.digitallibrary.features.digitalresource.domain.DigitalResource;
 import com.iesam.digitallibrary.features.digitalresource.domain.DigitalResourceRepository;
 
+import java.util.List;
+
 public class DigitalResourceDataRepository implements DigitalResourceRepository {
 
     public DigitalResourceFileLocalDataSource dRLocal;
@@ -13,8 +15,8 @@ public class DigitalResourceDataRepository implements DigitalResourceRepository 
     }
 
     @Override
-    public void getDigitalResources() {
-        dRLocal.findAll();
+    public List<DigitalResource> getDigitalResources() {
+        return dRLocal.findAll();
     }
 
     @Override

--- a/src/main/java/com/iesam/digitallibrary/features/digitalresource/domain/DigitalResourceRepository.java
+++ b/src/main/java/com/iesam/digitallibrary/features/digitalresource/domain/DigitalResourceRepository.java
@@ -1,7 +1,10 @@
 package com.iesam.digitallibrary.features.digitalresource.domain;
 
+import java.util.List;
+
 public interface DigitalResourceRepository {
 
-    void getDigitalResources();
+    List<DigitalResource> getDigitalResources();
+
     DigitalResource getDigitalResource(String isbn);
 }

--- a/src/main/java/com/iesam/digitallibrary/features/loan/data/LoanDataRepository.java
+++ b/src/main/java/com/iesam/digitallibrary/features/loan/data/LoanDataRepository.java
@@ -8,9 +8,10 @@ import java.util.List;
 
 public class LoanDataRepository implements LoanRepository {
 
-    LoanFileLocalDataSource loanFileLocalDataSource = new LoanFileLocalDataSource();
+    LoanFileLocalDataSource loanFileLocalDataSource;
 
     public LoanDataRepository(LoanFileLocalDataSource loanFileLocalDataSource) {
+        this.loanFileLocalDataSource = loanFileLocalDataSource;
     }
 
     @Override
@@ -28,3 +29,5 @@ public class LoanDataRepository implements LoanRepository {
         this.loanFileLocalDataSource.delete(id);
     }
 }
+
+

--- a/src/test/java/com/iesam/digitallibrary/features/digitalresource/audiobook/data/AudiobookDataRepositoryTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/digitalresource/audiobook/data/AudiobookDataRepositoryTest.java
@@ -1,0 +1,102 @@
+package com.iesam.digitallibrary.features.digitalresource.audiobook.data;
+
+import com.iesam.digitallibrary.features.digitalresource.audiobook.data.local.AudiobookFileLocalDataSource;
+import com.iesam.digitallibrary.features.digitalresource.audiobook.domain.Audiobook;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class AudiobookDataRepositoryTest {
+
+    @Mock
+    private AudiobookFileLocalDataSource audiobookFileLocalDataSource;
+
+    private AudiobookDataRepository audiobookDataRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        audiobookDataRepository = new AudiobookDataRepository(audiobookFileLocalDataSource);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reset(audiobookFileLocalDataSource);
+    }
+
+    @Test
+    void createAudiobookSuccessfully() {
+        // Given
+        Audiobook audiobook = new Audiobook("isbn1", "title1", "author1", "narrator1", "duration1");
+
+        // When
+        audiobookDataRepository.createAudiobook(audiobook);
+
+        // Then
+        Mockito.verify(audiobookFileLocalDataSource, Mockito.times(1)).save(audiobook);
+    }
+
+    @Test
+    void getAudiobooksSuccessfully() {
+        // Given
+        Audiobook audiobook1 = new Audiobook("isbn1", "title1", "author1", "narrator1", "duration1");
+        Audiobook audiobook2 = new Audiobook("isbn2", "title2", "author2", "narrator2", "duration2");
+        List<Audiobook> expectedAudiobooks = Arrays.asList(audiobook1, audiobook2);
+        Mockito.when(audiobookFileLocalDataSource.findAll()).thenReturn(expectedAudiobooks);
+
+        // When
+        List<Audiobook> audiobooks = audiobookDataRepository.getAudiobooks();
+
+        // Then
+        Mockito.verify(audiobookFileLocalDataSource, Mockito.times(1)).findAll();
+        Assertions.assertEquals(expectedAudiobooks, audiobooks);
+    }
+
+    @Test
+    void getAudiobookSuccessfully() {
+        // Given
+        String isbn = "isbn1";
+        Audiobook expectedAudiobook = new Audiobook(isbn, "title1", "author1", "narrator1", "duration1");
+        Mockito.when(audiobookFileLocalDataSource.findById(isbn)).thenReturn(expectedAudiobook);
+
+        // When
+        Audiobook audiobook = audiobookDataRepository.getAudiobook(isbn);
+
+        // Then
+        Mockito.verify(audiobookFileLocalDataSource, Mockito.times(1)).findById(isbn);
+        Assertions.assertEquals(expectedAudiobook, audiobook);
+    }
+
+    @Test
+    void deleteAudiobookSuccessfully() {
+        // Given
+        String isbn = "isbn1";
+
+        // When
+        audiobookDataRepository.deleteAudiobook(isbn);
+
+        // Then
+        Mockito.verify(audiobookFileLocalDataSource, Mockito.times(1)).delete(isbn);
+    }
+
+    @Test
+    void updateAudiobookSuccessfully() {
+        // Given
+        Audiobook audiobook = new Audiobook("isbn1", "title1", "author1", "narrator1", "duration1");
+
+        // When
+        audiobookDataRepository.updateAudiobook(audiobook);
+
+        // Then
+        Mockito.verify(audiobookFileLocalDataSource, Mockito.times(1)).update(audiobook);
+    }
+}

--- a/src/test/java/com/iesam/digitallibrary/features/digitalresource/data/DigitalResourceDataRepositoryTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/digitalresource/data/DigitalResourceDataRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.iesam.digitallibrary.features.digitalresource.data;
+
+import com.iesam.digitallibrary.features.digitalresource.data.local.DigitalResourceFileLocalDataSource;
+import com.iesam.digitallibrary.features.digitalresource.domain.DigitalResource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+@ExtendWith(MockitoExtension.class)
+public class DigitalResourceDataRepositoryTest {
+
+    @Mock
+    private DigitalResourceFileLocalDataSource digitalResourceFileLocalDataSource;
+
+    private DigitalResourceDataRepository digitalResourceDataRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        digitalResourceDataRepository = new DigitalResourceDataRepository(digitalResourceFileLocalDataSource);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reset(digitalResourceFileLocalDataSource);
+    }
+
+    @Test
+    void getDigitalResourcesSuccessfully() {
+        // Given
+        DigitalResource resource1 = new DigitalResource("isbn1", "title1", "author1", "genre1", "year1");
+        DigitalResource resource2 = new DigitalResource("isbn2", "title2", "author2", "genre2", "year2");
+        List<DigitalResource> expectedResources = Arrays.asList(resource1, resource2);
+        when(digitalResourceFileLocalDataSource.findAll()).thenReturn(expectedResources);
+
+        // When
+        List<DigitalResource> resources = digitalResourceDataRepository.getDigitalResources();
+
+        // Then
+        verify(digitalResourceFileLocalDataSource, times(1)).findAll();
+        assertEquals(expectedResources, resources);
+    }
+
+    @Test
+    void getDigitalResourceSuccessfully() {
+        // Given
+        String isbn = "isbn1";
+        DigitalResource expectedResource = new DigitalResource(isbn, "title1", "author1", "genre1", "year1");
+        when(digitalResourceFileLocalDataSource.findById(isbn)).thenReturn(expectedResource);
+
+        // When
+        DigitalResource resource = digitalResourceDataRepository.getDigitalResource(isbn);
+
+        // Then
+        verify(digitalResourceFileLocalDataSource, times(1)).findById(isbn);
+        assertEquals(expectedResource, resource);
+    }
+}

--- a/src/test/java/com/iesam/digitallibrary/features/digitalresource/ebook/data/EBookDataRepositoryTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/digitalresource/ebook/data/EBookDataRepositoryTest.java
@@ -1,0 +1,104 @@
+package com.iesam.digitallibrary.features.digitalresource.ebook.data;
+
+import com.iesam.digitallibrary.features.digitalresource.ebook.data.EBookDataRepository;
+import com.iesam.digitallibrary.features.digitalresource.ebook.data.local.EBookFileLocalDataSource;
+import com.iesam.digitallibrary.features.digitalresource.ebook.domain.EBook;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class EBookDataRepositoryTest {
+
+    @Mock
+    private EBookFileLocalDataSource eBookFileLocalDataSource;
+
+    private EBookDataRepository eBookDataRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        eBookDataRepository = new EBookDataRepository(eBookFileLocalDataSource);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Mockito.reset(eBookFileLocalDataSource);
+    }
+
+    @Test
+    void createEBookSuccessfully() {
+        // Given
+        EBook eBook = new EBook("isbn1", "title1", "author1", "genre1", "year1");
+
+        // When
+        eBookDataRepository.createEBook(eBook);
+
+        // Then
+        Mockito.verify(eBookFileLocalDataSource, Mockito.times(1)).save(eBook);
+    }
+
+    @Test
+    void deleteEBookSuccessfully() {
+        // Given
+        String isbn = "isbn1";
+
+        // When
+        eBookDataRepository.deleteEBook(isbn);
+
+        // Then
+        Mockito.verify(eBookFileLocalDataSource, Mockito.times(1)).delete(isbn);
+    }
+
+    @Test
+    void getEBookSuccessfully() {
+        // Given
+        String isbn = "isbn1";
+        EBook expectedEBook = new EBook(isbn, "title1", "author1", "genre1", "year1");
+        Mockito.when(eBookFileLocalDataSource.findById(isbn)).thenReturn(expectedEBook);
+
+        // When
+        EBook eBook = eBookDataRepository.getEBook(isbn);
+
+        // Then
+        Mockito.verify(eBookFileLocalDataSource, Mockito.times(1)).findById(isbn);
+        assertEquals(expectedEBook, eBook);
+    }
+
+    @Test
+    void getEBooksSuccessfully() {
+        // Given
+        EBook eBook1 = new EBook("isbn1", "title1", "author1", "genre1", "year1");
+        EBook eBook2 = new EBook("isbn2", "title2", "author2", "genre2", "year2");
+        List<EBook> expectedEBooks = Arrays.asList(eBook1, eBook2);
+        when(eBookFileLocalDataSource.findAll()).thenReturn(expectedEBooks);
+
+        // When
+        List<EBook> eBooks = eBookDataRepository.getEBooks();
+
+        // Then
+        Mockito.verify(eBookFileLocalDataSource, Mockito.times(1)).findAll();
+        assertEquals(expectedEBooks, eBooks);
+    }
+
+    @Test
+    void updateEBookSuccessfully() {
+        // Given
+        EBook eBook = new EBook("isbn1", "title1", "author1", "genre1", "year1");
+
+        // When
+        eBookDataRepository.updateEBook(eBook);
+
+        // Then
+        Mockito.verify(eBookFileLocalDataSource, Mockito.times(1)).update(eBook);
+    }
+}
+

--- a/src/test/java/com/iesam/digitallibrary/features/loan/data/LoanDataRepositoryTest.java
+++ b/src/test/java/com/iesam/digitallibrary/features/loan/data/LoanDataRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.iesam.digitallibrary.features.loan.data;
+
+import com.iesam.digitallibrary.features.digitalresource.domain.DigitalResource;
+import com.iesam.digitallibrary.features.loan.data.local.LoanFileLocalDataSource;
+import com.iesam.digitallibrary.features.loan.domain.Loan;
+import com.iesam.digitallibrary.features.user.domain.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class LoanDataRepositoryTest {
+
+    @Mock
+    private LoanFileLocalDataSource loanFileLocalDataSource;
+
+    private LoanDataRepository loanDataRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        loanDataRepository = new LoanDataRepository(loanFileLocalDataSource);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reset(loanFileLocalDataSource);
+    }
+
+    @Test
+    void createLoanSuccessfully() {
+        // Given
+        User user = new User("100","dni", "nombre", "ape", "email", "age", "tel");
+        DigitalResource digitalResource = new DigitalResource("isbn","title", "author", "genre", "year");
+
+        Loan loan = new Loan("1", user, digitalResource, "2023-05-01", "2023-05-15");
+
+        // When
+        loanDataRepository.createLoan(loan);
+
+        // Then
+        Mockito.verify(loanFileLocalDataSource, Mockito.times(1)).save(loan);
+    }
+
+
+    @Test
+    void getLoansSuccessfully() {
+        // Given
+
+        User user = new User("100","dni", "nombre", "ape", "email", "age", "tel");
+        DigitalResource digitalResource = new DigitalResource("isbn","title", "author", "genre", "year");
+        List<Loan> expectedLoans = Arrays.asList(
+                new Loan("1", user, digitalResource, "2023-05-01", "2023-05-15"),
+                new Loan("2", user, digitalResource, "2023-05-02", "2023-05-16")
+        );
+        Mockito.when(loanFileLocalDataSource.findAll()).thenReturn(expectedLoans);
+
+        // When
+        List<Loan> loans = loanDataRepository.getLoans();
+
+        // Then
+        Assertions.assertEquals(expectedLoans, loans);
+    }
+
+    @Test
+    void deleteLoanSuccessfully() {
+        // Given
+        String loanId = "1";
+
+        // When
+        loanDataRepository.deleteLoan(loanId);
+
+        // Then
+        Mockito.verify(loanFileLocalDataSource, Mockito.times(1)).delete(loanId);
+    }
+}


### PR DESCRIPTION
closes #64 

## 📝 Breve descripción del ticket asociado a esta PR
Se requiere realizar test unitarios para las clases `DataRepository` que no había sido testeadas aún.(`Loan`, `Audiobook`, `EBook`, `DigitalResource`)
## 👩‍💻 Resumen de los cambios introducidos

Se han agregado pruebas unitarias para las capas de datos de los modelos restantes (Recurso Digital, Audiolibro, Libro Electrónico, Préstamo). Cada repositorio de datos ha sido probado para garantizar el correcto funcionamiento de sus métodos de creación, lectura, actualización y eliminación.

## 👁️ Partes del código debe ser revisado con más atención

Se debe revisar detenidamente la implementación de las pruebas unitarias para garantizar que cubran todos los casos de uso y que los métodos de los repositorios de datos se comporten como se espera en diferentes situaciones. 

## 📸 Screenshot o Video
**Test Audiobook**
![image](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/e14e294b-ba67-4cde-8b3d-52f45585110b)

**Test EBook**
![image](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/1522bf02-ae65-4acf-b3b9-6a71ca168e14)

**Test Loan**
![image](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/0e0419c0-675e-46ae-a52b-eaa86396a21b)

**Test Digital Resource**
![image](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/0d97e976-1e52-4a86-9f75-a52446660ddd)

## ✅ Checklist
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] El proyecto compila y se ejecuta correctamente.
- [x] El código se ha probado con todas las opciones posibles.
- [x] El código ha sido formateado.
- [x] He eliminado código de prueba.
- [x] Se han añadido test unitarios.

## ✋ Notas adicionales (Disclaimer)
Nada que argumentar.
## 🌈 Añade un Gif que represente a esta PR
![rocky-balboa-the-italian-stallion](https://github.com/AlejandrodePablo/ed-digital-library/assets/115726867/b46ebcd9-4110-44a5-b87f-a8fec7af0cf1)
